### PR TITLE
Fix unhandled CME error code 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ usage: nrfcredstore [--baudrate BAUDRATE] [--timeout TIMEOUT] dev delete SECURE_
 
 ### generate subcommand
 
+> [!IMPORTANT]
+> This command requires modem firmware version greater than or equal to 1.3.0.
+
 Generate a private key in the modem and output a certificate signing request.
 
 ```

--- a/src/nrfcredstore/at_client.py
+++ b/src/nrfcredstore/at_client.py
@@ -1,6 +1,7 @@
 from nrfcredstore.exceptions import ATCommandError, NoATClientException
 
 ERR_CODE_TO_MSG = {
+    0:   'AT command not supported by firmware version. Upgrade modem firmware?',
     513: 'Not found',
     514: 'Not allowed',
     515: 'Memory full',

--- a/tests/test_at_client.py
+++ b/tests/test_at_client.py
@@ -39,6 +39,10 @@ class TestATClient:
         self.serial.readline.return_value = '+CME ERROR: 514\r\n'.encode('utf-8')
 
     @pytest.fixture
+    def error_code_0_resp(self, at_client):
+        self.serial.readline.return_value = '+CME ERROR: 0\r\n'.encode('utf-8')
+
+    @pytest.fixture
     def error_ok_resp(self, at_client):
         self.serial.readline.side_effect = [b'ERROR', b'OK']
 
@@ -109,6 +113,11 @@ class TestATClient:
         with pytest.raises(ATCommandError) as excinfo:
             at_client.at_command('AT')
         assert 'Not allowed' in str(excinfo.value)
+
+    def test_unsupported_cmd_error_code(self, at_client, error_code_0_resp):
+        with pytest.raises(ATCommandError) as excinfo:
+            at_client.at_command('AT')
+        assert 'AT command not supported by firmware version' in str(excinfo.value)
 
     def test_at_command_with_single_line_response(self, at_client):
         self.serial.readline.side_effect = [b'single', b'OK']


### PR DESCRIPTION
The `%KEYGEN` command is not supported by modem firmware versions <1.3.0. On older versions the modem will respond with the error `+CME ERROR: 0` when attempting to use the keygen command. Because the error code `0` was not in the mapping, it would result in a stacktrace from python instead of a useful error message.

This adds an error message for error code 0 and a test to verify.

Also added a note about firmware version requirements to the `generate` command in the readme.

Fixes #8