### PR TITLE
Add CLI support for CSR attributes

### DIFF
--- a/src/nrfcredstore/cli.py
+++ b/src/nrfcredstore/cli.py
@@ -59,6 +59,8 @@ def parse_args(in_args):
         help='Secure tag to store generated key')
     generate_parser.add_argument('file', type=argparse.FileType('wb'),
         help='File to store CSR in DER format')
+    generate_parser.add_argument('--attributes', type=str, default='',
+        help='Comma-separated list of attribute ID and value pairs for the CSR response')
 
     return parser.parse_args(in_args)
 
@@ -90,7 +92,7 @@ def exec_cmd(args, credstore):
         else:
             raise RuntimeError('delete failed')
     elif args.subcommand=='generate':
-        credstore.keygen(args.tag, args.file)
+        credstore.keygen(args.tag, args.file, args.attributes)
         print(f'New private key generated in secure tag {args.tag}')
         print(f'Wrote CSR in DER format to {args.file.name}')
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,13 +98,19 @@ class TestCli():
     def test_generate_tag(self, mock_file, credstore, offline):
         credstore.keygen.return_value = True
         main(['fakedev', 'generate', '123', 'foo.der'], credstore)
-        credstore.keygen.assert_called_with(123, ANY)
+        credstore.keygen.assert_called_with(123, ANY, ANY)
 
     @patch('builtins.open')
     def test_generate_file(self, mock_file, credstore, offline):
         credstore.keygen.return_value = True
         main(['fakedev', 'generate', '123', 'foo.der'], credstore)
         mock_file.assert_called_with('foo.der', 'wb', ANY, ANY, ANY)
+
+    @patch('builtins.open')
+    def test_generate_with_attributes(self, credstore, offline):
+        credstore.keygen.return_value = True
+        main(['fakedev', 'generate', '123', 'foo.der', '--attributes', 'CN=foo'], credstore)
+        credstore.keygen.assert_called_with(123, ANY, 'CN=foo')
 
     def test_no_at_client_exit_code(self, credstore, at_client):
         at_client.verify.side_effect = NoATClientException()

--- a/tests/test_credstore.py
+++ b/tests/test_credstore.py
@@ -125,9 +125,9 @@ dGVzdA==
         self.at_client.at_command.assert_called_with(f'AT%KEYGEN=12345678,2,0')
 
     def test_generate_with_attributes(self, cred_store, csr_resp):
-        cred_store.keygen(12345678, Mock(), 'O=Nordic Semiconductor,L=Trondheim,C=no')
+        cred_store.keygen(12345678, Mock(), 'O=Nordic Semiconductor,L=Trondheim,C=no,CN=mydevice')
         self.at_client.at_command.assert_called_with(
-            f'AT%KEYGEN=12345678,2,0,"O=Nordic Semiconductor,L=Trondheim,C=no"')
+            f'AT%KEYGEN=12345678,2,0,"O=Nordic Semiconductor,L=Trondheim,C=no,CN=mydevice"')
 
     def test_generate_writes_csr_to_stream(self, cred_store, csr_resp):
         fake_binary_file = Mock()


### PR DESCRIPTION
Add optional `--attributes` argument to the `generate` command that is forwarded to the modem when generating a new client key. This will be included in the CSR, and in the signed certificate.

Typically this is used to set the Common Name (CN) to the device name that is registered in the cloud to authenticate the device.