### PR TITLE
Do not add newline to credentials

### DIFF
--- a/src/nrfcredstore/credstore.py
+++ b/src/nrfcredstore/credstore.py
@@ -77,7 +77,7 @@ class CredStore:
 
         if type == CredType.ANY:
             raise ValueError
-        cert = '\n' + file.read().rstrip()
+        cert = file.read().rstrip()
         return is_ok(self.at_client.at_command(f'AT%CMNG=0,{tag},{type.value},"{cert}"'))
 
     def delete(self, tag: int, type: CredType):

--- a/tests/test_credstore.py
+++ b/tests/test_credstore.py
@@ -109,7 +109,7 @@ dGVzdA==
 -----END CERTIFICATE-----'''
         fake_file = io.StringIO(cert_text)
         assert cred_store.write(567890, CredType.CLIENT_KEY, fake_file)
-        self.at_client.at_command.assert_called_with(f'AT%CMNG=0,567890,2,"\n{cert_text}"')
+        self.at_client.at_command.assert_called_with(f'AT%CMNG=0,567890,2,"{cert_text}"')
 
     def test_write_fail(self, cred_store, at_error):
         with pytest.raises(ATCommandError):


### PR DESCRIPTION
This is not needed and aligns credstore with the way
nRF Connect's Cellular Monitor's Device Manager
provisions certificates.