### PR TITLE
Fix list command with blank lines

### DIFF
--- a/src/nrfcredstore/credstore.py
+++ b/src/nrfcredstore/credstore.py
@@ -61,6 +61,8 @@ class CredStore:
                 cmd = f'{cmd},{CredType(type).value}'
 
         response_lines = self.at_client.at_command(cmd)
+        response_lines = [line for line in response_lines if line.strip()]
+
         columns = map(lambda line: line.replace('%CMNG: ', '').replace('"', '').split(','), response_lines)
         cred_map = map(lambda columns:
                 Credential(int(columns[0]), int(columns[1]), columns[2].strip()),

--- a/tests/test_credstore.py
+++ b/tests/test_credstore.py
@@ -26,6 +26,15 @@ class TestCredStore:
         ]
 
     @pytest.fixture
+    def list_all_resp_blank_lines(self, cred_store):
+        cred_store.at_client.at_command.return_value = [
+            '',
+            '%CMNG: 12345678, 0, "978C...02C4"',
+            '%CMNG: 567890, 1, "C485...CF09"',
+            ''
+        ]
+
+    @pytest.fixture
     def ok_resp(self, cred_store):
         cred_store.at_client.at_command.return_value = []
 
@@ -78,6 +87,12 @@ class TestCredStore:
         assert first.sha == '978C...02C4'
 
     def test_list_all_credentials_returns_multiple_credentials(self, cred_store, list_all_resp):
+        result = cred_store.list()
+        assert len(result) == 2
+        assert result[0].sha == '978C...02C4'
+        assert result[1].sha == 'C485...CF09'
+
+    def test_list_all_with_blank_lines_in_resp(self, cred_store, list_all_resp_blank_lines):
         result = cred_store.list()
         assert len(result) == 2
         assert result[0].sha == '978C...02C4'


### PR DESCRIPTION
Some versions of at_client print blank lines before/after the list of certificates. This commit filters out blank lines from the response.

Resolves #15