### PR TITLE
nrfcredstore: Fix delete response unhandled error

### DIFF
--- a/src/nrfcredstore/credstore.py
+++ b/src/nrfcredstore/credstore.py
@@ -27,7 +27,7 @@ class Credential:
         self.sha = sha
 
 def is_ok(response_lines):
-    return len(response_lines) == 0
+    return not any("ERROR" in line for line in response_lines)
 
 class CredStore:
     def __init__(self, at_client):

--- a/src/nrfcredstore/credstore.py
+++ b/src/nrfcredstore/credstore.py
@@ -27,7 +27,7 @@ class Credential:
         self.sha = sha
 
 def is_ok(response_lines):
-    return not any("ERROR" in line for line in response_lines)
+    return not any("ERROR" in line for line in response_lines) 
 
 class CredStore:
     def __init__(self, at_client):


### PR DESCRIPTION
When deleting a sectag, the tool returned an unhandled error even though the operation was successful. 